### PR TITLE
add other projections in pcolormesh bug fix

### DIFF
--- a/lib/cartopy/mpl/geoaxes.py
+++ b/lib/cartopy/mpl/geoaxes.py
@@ -1675,6 +1675,9 @@ class GeoAxes(matplotlib.axes.Axes):
                                ccrs._WarpedRectangularProjection,
                                ccrs.InterruptedGoodeHomolosine,
                                ccrs.Mercator,
+                               ccrs.LambertAzimuthalEqualArea,
+                               ccrs.AzimuthalEquidistant,
+                               ccrs.TransverseMercator,
                                ccrs.Stereographic)
             if isinstance(t, wrap_proj_types) and \
                     isinstance(self.projection, wrap_proj_types):


### PR DESCRIPTION
Including 3 more projections in your bug fix #1420 mentioned in cartopy issue #1447.

<!--

Thanks for contributing to cartopy!
Please use this template as a guide to streamline the pull request you are about to make.

Remember: it is significantly easier to merge small pull requests. Consider whether this pull
request could be broken into smaller parts before submitting.

-->



## Rationale
This fixes the problems described in #1447.

<!-- Please provide detail as to *why* you are making this change. -->


## Implications

<!-- If applicable, to the best of your knowledge, what are the implications of this change? -->
None that I can see.

<!--
## Checklist

 * If you have not already done so, ensure you've read and signed the Contributor Licence Agreement (CLA).
   (See the [governance page](http://scitools.org.uk/governance.html) for the CLA and what to do with it).

 * If this is a new feature, please provide an example of its use in the description. We may want to make a
   follow-on pull request to put the example in the gallery!

 * Ensure there is a suitable item in the cartopy test suite for the change you are proposing. 

-->
